### PR TITLE
feat: remove S3 backend bucket from terraform block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/terraform.tfstate
 **/terraform.tfstate.backup
 terraform/builds
+terraform/backend.config
 
 package.zip
 __pycache__/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,7 @@ tasks:
     desc: Initialize Terraform code
     summary: Executes a 'terraform init' to initializes the Terraform working directory.
     cmds:
-      - terraform init
+      - terraform init -backend-config="./backend.config"
     dir: terraform/
 
   tf-plan:

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -9,7 +9,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket       = "eriks-terraform-state"
+    bucket       = ""
     key          = "sqs-simple-example/terraform.tfstate"
     region       = "us-west-2"
     encrypt      = true


### PR DESCRIPTION
Remove S3 backend bucket from `terraform{}` block.  It has been added to `backend.config` file which has been added to `.gitignore` file.  The `backend.config` file will be used in the init command like this: `terraform init -backend-config="./backend.config".