### PR TITLE
feat: update CodeBuild policy

### DIFF
--- a/cicd/codebuild-policy.tftpl
+++ b/cicd/codebuild-policy.tftpl
@@ -145,6 +145,13 @@
 		},
 		{
 			"Effect": "Allow",
+			"Action": [
+				"ssm:GetParameter"
+			],
+			"Resource": "arn:aws:ssm:${Region}:${Account}:parameter/core-infra/terraform-state-bucket-name"
+		},
+		{
+			"Effect": "Allow",
 			"Action": "sns:*",
 			"Resource": "arn:aws:sns:${Region}:${Account}:${ProjectName}-*"
 		}

--- a/cicd/terraform.tf
+++ b/cicd/terraform.tf
@@ -9,7 +9,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket       = "***REMOVED***"
+    bucket       = ""
     key          = "codebuild/sqs-simple-example/terraform.tfstate"
     region       = "us-west-2"
     encrypt      = true


### PR DESCRIPTION
Updated CodeBuild policy to allow access to read the SSM Parameter Store parameter for the Terraform state S3 backend bucket.